### PR TITLE
Fix config for FR translation

### DIFF
--- a/languages/fr-FR.json
+++ b/languages/fr-FR.json
@@ -5,6 +5,6 @@
 	"PotatoOrNot.MediumDescription": "Tu as un ordinateur milieu de gamme qui n'est pas mauvais, mais qui commence à prendre de l'âge.",
 	"PotatoOrNot.GoodTitle": "Patate de luxe",
 	"PotatoOrNot.GoodDescription": "Ton ordinateur puissant est presque membre du club VIP.",
-	"PotatoOrNot.Selection": "Sélectionne le niveau de qualité de ton ordinateur :",
+	"PotatoOrNot.Selection": "Sélectionne le niveau de performance de ton ordinateur :",
 	"PotatoOrNot.Accept": "Accepter"
 }

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -5,6 +5,6 @@
 	"PotatoOrNot.MediumDescription": "Tu as un ordinateur milieu de gamme qui n'est pas mauvais, mais qui commence à prendre de l'âge.",
 	"PotatoOrNot.GoodTitle": "Patate de luxe",
 	"PotatoOrNot.GoodDescription": "Ton ordinateur puissant est presque membre du club VIP.",
-	"PotatoOrNot.Selection": "Sélectionne le niveau de qualité de ton ordinateur :",
+	"PotatoOrNot.Selection": "Sélectionne le niveau de performance de ton ordinateur :",
 	"PotatoOrNot.Accept": "Accepter"
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "potato-or-not",
   "title": "Potato Or Not",
   "description": "Is your computer a potato or not? If so, this mod will prompt you that you might want to turn down your graphics.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "minimumCoreVersion": "10",
   "compatibility": {
     "minimum": "10",
@@ -27,6 +27,11 @@
       "lang": "en",
       "name": "English",
       "path": "languages/en.json"
+    },
+    {
+      "lang": "fr",
+      "name": "Français",
+      "path": "languages/fr.json"
     },
     {
       "lang": "fr-FR",


### PR DESCRIPTION
Tested on Foundry v10 (screenshot)

![test-potato](https://user-images.githubusercontent.com/3756769/229593425-18a93b2c-4e72-48ea-9823-21862164b496.jpg)

I left the translation and config for FR-fr which is maybe used in old Foundry versions (pre-9)